### PR TITLE
Shorten sa name

### DIFF
--- a/modules/bucket/main.tf
+++ b/modules/bucket/main.tf
@@ -4,7 +4,7 @@ terraform {
 
 provider "kubernetes" {
   version = "~> 1.10"
-  # host    = "127.0.0.1:8001" // kubectl proxy
+  host    = "127.0.0.1:8001" // kubectl proxy
 }
 
 provider "google" {
@@ -12,7 +12,7 @@ provider "google" {
 }
 
 locals {
-  sa_name = "${var.labels.app}-${substr(var.kubernetes_namespace, 0, 3)}-${var.bucket_instance_suffix}"
+  sa_name = "${var.labels.app}-${var.bucket_instance_suffix}"
 }
 
 resource "null_resource" "is_environment_valid" {
@@ -21,7 +21,7 @@ resource "null_resource" "is_environment_valid" {
 
 # Create bucket
 resource "google_storage_bucket" "storage_bucket" {
-  name               = "${var.labels.team}-${var.labels.app}-${var.kubernetes_namespace}-${var.bucket_instance_suffix}"
+  name               = "${var.labels.team}-${var.labels.app}-${var.bucket_instance_suffix}"
   force_destroy      = false
   location           = var.location
   project            = var.gcp_project
@@ -34,7 +34,7 @@ resource "google_storage_bucket" "storage_bucket" {
   }
   logging {
     log_bucket        = var.log_bucket
-    log_object_prefix = "${var.labels.team}-${var.labels.app}-${var.kubernetes_namespace}-${var.bucket_instance_suffix}"
+    log_object_prefix = "${var.labels.team}-${var.labels.app}-${var.bucket_instance_suffix}"
   }
 }
 
@@ -68,7 +68,7 @@ resource "kubernetes_secret" "storage_bucket_service_account_credentials" {
     google_storage_bucket.storage_bucket
   ]
   metadata {
-    name      = "${var.labels.team}-${var.labels.app}-${var.kubernetes_namespace}-${var.bucket_instance_suffix}-credentials"
+    name      = "${var.labels.team}-${var.labels.app}-${var.bucket_instance_suffix}-credentials"
     namespace = var.kubernetes_namespace
   }
   data = {

--- a/modules/bucket/main.tf
+++ b/modules/bucket/main.tf
@@ -4,7 +4,7 @@ terraform {
 
 provider "kubernetes" {
   version = "~> 1.10"
-  host    = "127.0.0.1:8001" // kubectl proxy
+  # host    = "127.0.0.1:8001" // kubectl proxy
 }
 
 provider "google" {

--- a/modules/bucket/variables.tf
+++ b/modules/bucket/variables.tf
@@ -22,8 +22,7 @@ variable "kubernetes_namespace" {
 }
 
 variable "bucket_instance_suffix" {
-  description = "A suffix for the bucket instance, may be changed if environment is destroyed and then needed again (name collision workaround)"
-  default     = "bucket"
+  description = "A suffix for the bucket instance, may be changed if environment is destroyed and then needed again (name collision workaround) - also bucket names must be globally unique"
 }
 
 variable "storage_class" {


### PR DESCRIPTION
bucket names need to be globally unique. Removing hard dependency on namespace name -> can be added using instance_suffix if needed.