### PR TITLE
pg cloudsql connection string to secret

### DIFF
--- a/examples/postgres-defaults/main.tf
+++ b/examples/postgres-defaults/main.tf
@@ -8,9 +8,9 @@ module "postgres" {
   gcp_project          = var.gcp_project
   labels               = var.labels
   kubernetes_namespace = var.kubernetes_namespace
-  db_name              = "example"
-  db_user              = "example-user"
-  region               = "europe-west1"
-  zoneLetter           = "d"
+  db_name              = var.db_name
+  db_user              = var.db_user
+  region               = var.region
+  zoneLetter           = var.zone_letter
   prevent_destroy      = var.prevent_destroy
 }

--- a/examples/postgres-defaults/variables.tf
+++ b/examples/postgres-defaults/variables.tf
@@ -3,6 +3,18 @@ variable "gcp_project" {
   description = "The GCP project id"
 }
 
+variable "region" {
+  description = "Target GCP region"
+  type        = string
+  default     = "entur-west1"
+}
+
+variable "zone_letter" {
+  description = "Letter of target GCP zone"
+  type        = string
+  default     = "d"
+}
+
 variable "labels" {
   description = "Labels used in all resources"
   type        = map(string)
@@ -21,4 +33,16 @@ variable "kubernetes_namespace" {
 variable "prevent_destroy" {
   description = "Prevent the destruction of this postgres database"
   type        = bool
+}
+
+variable "db_name" {
+  description = "Name of the database"
+  type        = string
+  default     = "example"
+}
+
+variable "db_user" {
+  description = "Name of the database user"
+  type        = string
+  default     = "example-user"
 }

--- a/examples/postgres-defaults/variables.tf
+++ b/examples/postgres-defaults/variables.tf
@@ -6,7 +6,7 @@ variable "gcp_project" {
 variable "region" {
   description = "Target GCP region"
   type        = string
-  default     = "entur-west1"
+  default     = "europe-west1"
 }
 
 variable "zone_letter" {

--- a/modules/postgres/README.md
+++ b/modules/postgres/README.md
@@ -26,9 +26,9 @@ Creates a postgresql named **team-app-namespace-suffix**: `${var.labels.team}-${
   - Render: `awesomeblog-db-credentials`
     - given
       - app = `awesomeblog`
-- `${var.labels.app}-instance-credentials` with `{ credentials.json: "PRIVATEKEY" }`
+- `${var.labels.app}-instance-credentials` with `{ credentials.json: "PRIVATEKEY", INSTANCES: "CLOUDSQL_CONNECTION_STRING" }`
   - `[app]-instance-credentials`
-  - Contains the credentials.json service account credentials
+  - Contains the credentials.json service account credentials and the connection string used by cloudsql_proxy
   - Render: `awesomeblog-instance-credentials`
     - given
       - app = `awesomeblog`

--- a/modules/postgres/main.tf
+++ b/modules/postgres/main.tf
@@ -95,6 +95,7 @@ resource "kubernetes_secret" "team-instance-credentials" {
     labels    = var.labels
   }
   data = {
-    "credentials.json" = "${base64decode(google_service_account_key.team-instance-credentials.private_key)}"
+    "credentials.json" = base64decode(google_service_account_key.team-instance-credentials.private_key)
+    INSTANCES          = "${module.sql-db_postgresql.instance_connection_name}=tcp:5432"
   }
 }


### PR DESCRIPTION
Added the connection string used by cloudsql proxy to the instance_credentials secret.
Refactored postgres-defaults example to allow overrides of database name, user, and location.