### PR TITLE
Random suffix generation in postgres module

### DIFF
--- a/modules/postgres/README.md
+++ b/modules/postgres/README.md
@@ -45,6 +45,7 @@ Creates a postgresql named **team-app-namespace-suffix**: `${var.labels.team}-${
 | labels.app | The name of this application / workload | string | n/a | yes |
 | kubernetes_namespace | The namespace you wish to target. This is the namespace that the secrets will be stored in | string | n/a | yes |
 | prevent_destroy | Prevents the destruction of the bucket | bool | false | no |
+| db_instance_custom_name | Database instance name override | string | n/a | no |
 | db_instance_suffix | A static suffix for the database instance name | string | n/a | no |
 | db_instance_random_suffix_append | Append additional random suffix to database instance name | bool | true | no |
 | db_instance_random_suffix_length | Random database instance name suffix length (bytes) | int | 2 | no |

--- a/modules/postgres/README.md
+++ b/modules/postgres/README.md
@@ -46,9 +46,6 @@ Creates a postgresql named **team-app-namespace-suffix**: `${var.labels.team}-${
 | kubernetes_namespace | The namespace you wish to target. This is the namespace that the secrets will be stored in | string | n/a | yes |
 | prevent_destroy | Prevents the destruction of the bucket | bool | false | no |
 | db_instance_custom_name | Database instance name override | string | n/a | no |
-| db_instance_suffix | A static suffix for the database instance name | string | n/a | no |
-| db_instance_random_suffix_append | Append additional random suffix to database instance name | bool | true | no |
-| db_instance_random_suffix_length | Random database instance name suffix length (bytes) | int | 2 | no |
 | db_instance_backup_enabled | Enable database backup | bool | true | no |
 | db_instance_backup_time | When the backup should be scheduled | string | "04:00" | no |
 | db_name | Name of the default database | string | n/a | no |

--- a/modules/postgres/README.md
+++ b/modules/postgres/README.md
@@ -42,9 +42,17 @@ Creates a postgresql named **team-app-namespace-suffix**: `${var.labels.team}-${
 | zoneLetter | The default zone [a,b,c,d,e etc] | string | n/a | yes |
 | labels | The labels you wish to decorate with | string | n/a | yes |
 | labels.team | The name of your team or department | string | n/a | yes |
-| labels.app | The name of this appliation / workload | string | n/a | yes |
+| labels.app | The name of this application / workload | string | n/a | yes |
 | kubernetes_namespace | The namespace you wish to target. This is the namespace that the secrets will be stored in | string | n/a | yes |
 | prevent_destroy | Prevents the destruction of the bucket | bool | false | no |
+| db_instance_suffix | A static suffix for the database instance name | string | n/a | no |
+| db_instance_random_suffix_append | Append additional random suffix to database instance name | bool | true | no |
+| db_instance_random_suffix_length | Random database instance name suffix length (bytes) | int | 2 | no |
+| db_instance_backup_enabled | Enable database backup | bool | true | no |
+| db_instance_backup_time | When the backup should be scheduled | string | "04:00" | no |
+| db_name | Name of the default database | string | n/a | no |
+| db_user | Default user for database | string | n/a | no |
+| postgresql_version | Which version to use | string | "POSTGRES_9_6" | no |
 
 ## Outputs
 

--- a/modules/postgres/main.tf
+++ b/modules/postgres/main.tf
@@ -39,7 +39,7 @@ module "sql-db_postgresql" {
   version = "2.0.0"
 
   database_version = var.postgresql_version
-  name             = length(var.db_instance_custom_name) > 0 ? var.db_instance_custom_name : "${var.labels.app}-${var.kubernetes_namespace}${var.db_instance_random_suffix_append ? random_id.suffix.hex : "-${var.db_instance_suffix}"}"
+  name             = length(var.db_instance_custom_name) > 0 ? var.db_instance_custom_name : "${var.labels.app}-${var.kubernetes_namespace}-${random_id.suffix.hex}"
   project_id       = var.gcp_project
   region           = var.region
   zone             = var.zoneLetter
@@ -74,8 +74,7 @@ resource "random_id" "protector" {
 }
 
 resource "random_id" "suffix" {
-    byte_length = var.db_instance_random_suffix_length > 0 ? var.db_instance_random_suffix_length : 1
-    prefix = length(var.db_instance_suffix) > 0 ? "-${var.db_instance_suffix}-" : "-"
+    byte_length = 2
 }
 
 resource "kubernetes_secret" "team-db-credentials" {

--- a/modules/postgres/main.tf
+++ b/modules/postgres/main.tf
@@ -37,9 +37,10 @@ resource "google_project_iam_member" "project" {
 module "sql-db_postgresql" {
   source  = "GoogleCloudPlatform/sql-db/google//modules/postgresql"
   version = "2.0.0"
+
   # insert the 4 required variables here
   database_version = var.postgresql_version
-  name             = "${var.labels.team}-${var.labels.app}-${var.kubernetes_namespace}-${var.db_instance_suffix}"
+  name             = "${var.labels.team}-${var.labels.app}-${var.kubernetes_namespace}${var.db_instance_random_suffix_append ? random_id.suffix.hex : var.db_instance_suffix}"
   project_id       = var.gcp_project
   region           = var.region
   zone             = var.zoneLetter
@@ -52,6 +53,7 @@ module "sql-db_postgresql" {
     require_ssl         = true
     authorized_networks = []
   }
+  
 
   user_name = var.db_user
 
@@ -71,6 +73,11 @@ resource "random_id" "protector" {
   lifecycle {
     prevent_destroy = true
   }
+}
+
+resource "random_id" "suffix" {
+    byte_length = var.db_instance_random_suffix_length > 0 ? var.db_instance_random_suffix_length : 1
+    prefix = var.db_instance_random_suffix_length > 0 ? "${var.db_instance_suffix}-" : var.db_instance_suffix
 }
 
 resource "kubernetes_secret" "team-db-credentials" {

--- a/modules/postgres/main.tf
+++ b/modules/postgres/main.tf
@@ -38,9 +38,8 @@ module "sql-db_postgresql" {
   source  = "GoogleCloudPlatform/sql-db/google//modules/postgresql"
   version = "2.0.0"
 
-  # insert the 4 required variables here
   database_version = var.postgresql_version
-  name             = "${var.labels.team}-${var.labels.app}-${var.kubernetes_namespace}${var.db_instance_random_suffix_append ? random_id.suffix.hex : var.db_instance_suffix}"
+  name             = length(var.db_instance_custom_name) > 0 ? var.db_instance_custom_name : "${var.labels.team}-${var.labels.app}-${var.kubernetes_namespace}${var.db_instance_random_suffix_append ? random_id.suffix.hex : "-${var.db_instance_suffix}"}"
   project_id       = var.gcp_project
   region           = var.region
   zone             = var.zoneLetter
@@ -53,7 +52,6 @@ module "sql-db_postgresql" {
     require_ssl         = true
     authorized_networks = []
   }
-  
 
   user_name = var.db_user
 
@@ -77,7 +75,7 @@ resource "random_id" "protector" {
 
 resource "random_id" "suffix" {
     byte_length = var.db_instance_random_suffix_length > 0 ? var.db_instance_random_suffix_length : 1
-    prefix = var.db_instance_random_suffix_length > 0 ? "${var.db_instance_suffix}-" : var.db_instance_suffix
+    prefix = length(var.db_instance_suffix) > 0 ? "-${var.db_instance_suffix}-" : "-"
 }
 
 resource "kubernetes_secret" "team-db-credentials" {

--- a/modules/postgres/main.tf
+++ b/modules/postgres/main.tf
@@ -39,7 +39,7 @@ module "sql-db_postgresql" {
   version = "2.0.0"
 
   database_version = var.postgresql_version
-  name             = length(var.db_instance_custom_name) > 0 ? var.db_instance_custom_name : "${var.labels.team}-${var.labels.app}-${var.kubernetes_namespace}${var.db_instance_random_suffix_append ? random_id.suffix.hex : "-${var.db_instance_suffix}"}"
+  name             = length(var.db_instance_custom_name) > 0 ? var.db_instance_custom_name : "${var.labels.app}-${var.kubernetes_namespace}${var.db_instance_random_suffix_append ? random_id.suffix.hex : "-${var.db_instance_suffix}"}"
   project_id       = var.gcp_project
   region           = var.region
   zone             = var.zoneLetter

--- a/modules/postgres/variables.tf
+++ b/modules/postgres/variables.tf
@@ -39,8 +39,19 @@ variable "postgresql_version" {
 }
 
 variable "db_instance_suffix" {
-  description = "A suffix for the database instance, may be changed if environment is destroyed and then needed again (name collision workaround)"
-  default     = "postgres"
+  description = "A static suffix for the database instance name (including separator, i.e. '-db')"
+  default     = ""
+}
+
+variable "db_instance_random_suffix_append" {
+  description = "Append additional random suffix to database instance name, to avoid name collision"
+  type        = bool
+  default     = true
+}
+
+variable "db_instance_random_suffix_length" {
+  description = "Random database instance name suffix length (in bytes, i.e. 2 bytes = 4 char)"
+  default     = 2
 }
 
 variable "db_instance_backup_enabled" {

--- a/modules/postgres/variables.tf
+++ b/modules/postgres/variables.tf
@@ -38,9 +38,14 @@ variable "postgresql_version" {
   default     = "POSTGRES_9_6"
 }
 
-variable "db_instance_suffix" {
-  description = "A static suffix for the database instance name (including separator, i.e. '-db')"
+variable "db_instance_custom_name" {
+  description = "Database instance name override (empty string = disabled)"
   default     = ""
+}
+
+variable "db_instance_suffix" {
+  description = "A static suffix for the database instance name"
+  default     = "postgres"
 }
 
 variable "db_instance_random_suffix_append" {

--- a/modules/postgres/variables.tf
+++ b/modules/postgres/variables.tf
@@ -39,24 +39,8 @@ variable "postgresql_version" {
 }
 
 variable "db_instance_custom_name" {
-  description = "Database instance name override (empty string = disabled)"
+  description = "Database instance name override (empty string = use standard convention)"
   default     = ""
-}
-
-variable "db_instance_suffix" {
-  description = "A static suffix for the database instance name"
-  default     = "postgres"
-}
-
-variable "db_instance_random_suffix_append" {
-  description = "Append additional random suffix to database instance name, to avoid name collision"
-  type        = bool
-  default     = true
-}
-
-variable "db_instance_random_suffix_length" {
-  description = "Random database instance name suffix length (in bytes, i.e. 2 bytes = 4 char)"
-  default     = 2
 }
 
 variable "db_instance_backup_enabled" {


### PR DESCRIPTION
* support for random suffix generation if toggled
* supports a static suffix, a randomly generated suffix, or both
* features: enable/disable random suffix, set random suffix length
* randomly generated suffix is hex string, i.e. "foo-dev-fa4e"
* default is 4 char hex string only: "my-great-app-dev-3d2a"
* updated readme
