### PR TITLE
Entur convention compliance module

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ Have fun terraforming!
 
 # Available Modules
 
+## [Bucket](./modules/bucket)
+
+## [Entur](./modules/entur)
+
 ## [Postgres](./modules/postgres)
     
 ## [Redis](./modules/redis)
-
-## [Bucket](./modules/bucket)
 
 ## [Secret](./modules/secret)
 

--- a/modules/entur/README.md
+++ b/modules/entur/README.md
@@ -7,10 +7,27 @@ This module is used to check whether Terraform resources are set up according to
 Checks for the existence of required labels, fails to plan if any are missing.
 
 ## Inputs
+### Labels variable
+Entur's conventions require you to provide certain labels in the format of a map containing strings. E.g.:
+
+```
+variable "labels" {
+  type        = map(string)
+  default = {
+    app     = "foo"
+    team    = "bar"
+  }
+}
+````
+
+#### Required labels:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| labels | The labels you wish to decorate with | string | n/a | yes | yes |
+| labels.app | App name | string | n/a | yes |
+| labels.team | Team name | string | n/a | yes |
+| labels.slack | Slack channel used to communicate about this resource | string | n/a | yes |
+| labels.type | Resource type (e.g. database, api) | string | n/a | yes |
 
 ## Outputs
 

--- a/modules/entur/README.md
+++ b/modules/entur/README.md
@@ -1,0 +1,19 @@
+# Entur convention compliance module
+
+This module is used to check whether Terraform resources are set up according to Entur conventions.
+
+## Main effect
+
+Checks for the existence of required labels, fails to plan if any are missing.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| labels | The labels you wish to decorate with | string | n/a | yes | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+|  n/a |  |

--- a/modules/entur/main.tf
+++ b/modules/entur/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
+resource "null_resource" "label_exists_app" {
+  count = length(var.labels.app) > 0 ? 1 : "Entur requires you to provide a labels.app value, this is the name of your application"
+}
+
+resource "null_resource" "label_exists_team" {
+  count = length(var.labels.team) > 0 ? 1 : "Entur requires you to provide a labels.team value, this is the name of your team"
+}
+
+resource "null_resource" "label_exists_slack" {
+  count = length(var.labels.slack) > 0 ? 1 : "Entur requires you to provide a labels.slack value, this is the Slack channel used to communicate about this resource"
+}
+
+resource "null_resource" "label_exists_type" {
+  count = length(var.labels.type) > 0 ? 1 : "Entur requires you to provide a labels.type value, which describes the resource type (e.g. backend/frontend/database/queue/proxy)"
+}

--- a/modules/entur/variables.tf
+++ b/modules/entur/variables.tf
@@ -1,0 +1,4 @@
+variable "labels" {
+  description = "Labels matching Entur's standards"
+  type        = map(string)
+}


### PR DESCRIPTION
* adds a separate module which checks if Entur's labelling conventions are met, to avoid having to implement the same requirements in every module
* added benefit of making the other modules more generic and useful to others outside Entur

This is originally @AlexanderBrevig's idea, I just came up with the name and a couple examples.