### PR TITLE
Custom account_id and bring-your-own-service-account support

### DIFF
--- a/modules/postgres/README.md
+++ b/modules/postgres/README.md
@@ -54,9 +54,11 @@ Creates a postgresql named **app-namespace-suffix**: `${var.labels.app}-${var.ku
 | db_instance_backup_time | When the backup should be scheduled | string | "04:00" | no |
 | db_instance_tier | The tier for the master instance | string | "db-custom-1-3840" | no |
 | db_instance_disk_size | The disk size for the master instance | string | "10" | no |
-| create_timeout | The optional timout that is applied to limit long database creates | string | "10m" | no |
-| delete_timeout | The optional timout that is applied to limit long database deletes | string | "10m" | no |
-| update_timeout | The optional timout that is applied to limit long database updates | string | "10m" | no |
+| create_timeout | The optional timeout that is applied to limit long database creates | string | "10m" | no |
+| delete_timeout | The optional timeout that is applied to limit long database deletes | string | "10m" | no |
+| update_timeout | The optional timeout that is applied to limit long database updates | string | "10m" | no |
+| account_id | Database service account id (name) override | string | "" | no |
+| account_id_use_existing | Set this to true if you want to use an existing service account | bool | false | no |
 
 > FYI: The auto-resize flag is set. `db_instance_disk_size` only takes effect on initial apply. If manual resize is required, use the Google Console.
 > 

--- a/modules/postgres/main.tf
+++ b/modules/postgres/main.tf
@@ -21,7 +21,8 @@ provider "google-beta" {
 resource "google_service_account" "team-instance-credentials" {
   count = var.account_id_use_existing == true ? 0 : 1
   account_id   = length(var.account_id) > 0 ? var.account_id : "${var.labels.app}-${var.kubernetes_namespace}-cred"
-  display_name = "Service Account for ${var.labels.team} team SQL"
+  display_name   = length(var.account_id) > 0 ? var.account_id : "${var.labels.app}-${var.kubernetes_namespace}-cred"
+  description = "Service Account for ${var.labels.app} SQL"
 }
 
 resource "google_service_account_key" "team-instance-credentials" {

--- a/modules/postgres/main.tf
+++ b/modules/postgres/main.tf
@@ -19,18 +19,20 @@ provider "google-beta" {
 }
 
 resource "google_service_account" "team-instance-credentials" {
-  account_id   = "${var.labels.app}-${var.kubernetes_namespace}-cred"
+  count = var.account_id_use_existing == true ? 0 : 1
+  account_id   = length(var.account_id) > 0 ? var.account_id : "${var.labels.app}-${var.kubernetes_namespace}-cred"
   display_name = "Service Account for ${var.labels.team} team SQL"
 }
 
 resource "google_service_account_key" "team-instance-credentials" {
-  service_account_id = google_service_account.team-instance-credentials.name
+  service_account_id = var.account_id_use_existing == true ? var.account_id : google_service_account.team-instance-credentials[0].name
 }
 
 resource "google_project_iam_member" "project" {
+  count = var.account_id_use_existing == true ? 0 : 1
   project = var.gcp_project
   role    = "roles/cloudsql.client"
-  member  = "serviceAccount:${google_service_account.team-instance-credentials.email}"
+  member  = "serviceAccount:${google_service_account.team-instance-credentials[0].email}"
 }
 
 //https://registry.terraform.io/modules/GoogleCloudPlatform/sql-db/google/2.0.0/submodules/postgresql

--- a/modules/postgres/variables.tf
+++ b/modules/postgres/variables.tf
@@ -58,6 +58,16 @@ variable "db_instance_custom_name" {
   default     = ""
 }
 
+variable "account_id" {
+  description = "Database service account id override (empty string = use standard convention)"
+  default     = ""
+}
+
+variable "account_id_use_existing" {
+  description = "Set this to true if you want to use an existing service account, otherwise a new one will be created (account_id must also be provided if set to true)"
+  default     = false
+}
+
 variable "db_instance_backup_enabled" {
   description = "Enable database backup"
   default     = true


### PR DESCRIPTION
* adds the option to use an existing service account (adds an additional key to an existing SA)
* adds the option to create a new service account with a custom name
* two new input variables:
  - account_id (string)
  - account_id_use_existing (bool)

**Example scenarios:**
```
+ no account_id set
+ account_id_use_existing not set
= uses default convention 
```

```
+ account_id set (existing service account)
+ account_id_use_existing set to false
= Error: Error creating service account: googleapi: Error 409: Service account x already exists within project projects/y., alreadyExists
```
```

+ account_id set (existing service account)
+ account_id_use_existing set to true
= new key is added to existing service account
```

```
+ account_id set (new)
+ account_id_use_existing set to false
= new account is added with custom name

```

