### PR TITLE
Redis: New naming convention and custom name override support

### DIFF
--- a/modules/redis/README.md
+++ b/modules/redis/README.md
@@ -35,7 +35,7 @@ Generated Kubernetes Config Map:
 | reserved_ip_range | The reserved IP range in CIDR notation | string | n/a | yes |
 | kubernetes_namespace | The namespace you wish to target. Note, this is only here to allow separate envs to have different redis instances. They do not actually live in the namespace. | string | n/a | yes |
 | prevent_destroy | Prevents the destruction of the bucket | bool | false | no |
-| redis_instance_suffix | The suffix of this redis instance | string | "redis" | no |
+| redis_instance_custom_name | Redis instance name override | string | n/a | no |
 | enable_apis | Flag for enabling redis API in your project | bool | false | no |
 
 ## Outputs

--- a/modules/redis/README.md
+++ b/modules/redis/README.md
@@ -4,14 +4,12 @@ This module can be used to quickly get a redis up and running according to Entur
 
 ## Main effect
 
-- `${var.labels.team}-${var.labels.app}-${var.kubernetes_namespace}-${var.redis_instance_suffix}`.
-  - `[app]-[namespace]-cred`
+- `${var.labels.app}-${var.kubernetes_namespace}-${random_id.suffix.hex}`.
+  - `[app]-[namespace]-[randomsuffix]`
   - Name of the Redis instance
-  - Render: `ninja-awesomeblog-production-redis`
-      - team = `ninja`
+  - Render: `awesomeblog-production-aa4c`
       - app = `awesomeblog`
       - namespace = `production`
-      - redis_instance_suffix = `redis`
 
 ## Side effects
 

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -13,7 +13,7 @@ module "memorystore" {
   source  = "terraform-google-modules/memorystore/google"
   version = "1.0.0"
 
-  name    = "${var.labels.team}-${var.labels.app}-${var.kubernetes_namespace}-${var.redis_instance_suffix}"
+  name     = length(var.redis_instance_custom_name) > 0 ? var.redis_instance_custom_name : "${var.labels.app}-${var.kubernetes_namespace}-${random_id.suffix.hex}"
   project = var.gcp_project
 
   location_id        = var.zone
@@ -35,6 +35,10 @@ resource "random_id" "protector" {
   lifecycle {
     prevent_destroy = true
   }
+}
+
+resource "random_id" "suffix" {
+  byte_length = 2
 }
 
 resource "kubernetes_config_map" "team-redis-configmap" {

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -25,9 +25,9 @@ variable "kubernetes_namespace" {
   description = "Your kubernetes namespace"
 }
 
-variable "redis_instance_suffix" {
-  description = "A suffix for the database instance, may be changed if environment is destroyed and then needed again (name collision workaround)"
-  default     = "redis"
+variable "redis_instance_custom_name" {
+  description = "Redis instance name override (empty string = use standard convention)"
+  default     = ""
 }
 
 variable "prevent_destroy" {


### PR DESCRIPTION
* changes default naming convention to match the convention used in the postgres module
* new default naming scheme is: appname-env-random (foo-dev-b3aa)
* adds new variable "redis_instance_custom_name" which allows to set a custom name override
* removes variable "redis_instance_suffix" (deprecated)

This is a potentially breaking change, which can be circumvented by using the custom name override var.