### PR TITLE
Bucket: New naming conventions, custom name and service account override support

### DIFF
--- a/modules/bucket/README.md
+++ b/modules/bucket/README.md
@@ -15,20 +15,19 @@ Creates a bucket named **app-namespace-suffix**: `${var.labels.app}-${var.kubern
 - `${var.labels.app}-${var.kubernetes_namespace}`
   - `[app]-[namespace]`
   - Name of the Service Account used by this bucket (name length < 30)
-  - Render: `awesome-pro-bucket`
+  - Render: `blog-production`
     - given
-      - app = `awesomeblog`
+      - app = `blog`
       - namespace = `production`
 
 ### Generated Kubernetes Secrets:
 
 - `${var.labels.app}-bucket-credentials` with `{ credentials.json: "PRIVATEKEY" }`
-  - `[app]-[namespace]-bucket-credentials`
+  - `[app]-bucket-credentials`
   - Contains the credentials.json service account credentials
   - Render: `blog-bucket-credentials`
     - given
-      - app = `awesomeblog`
-      - namespace = `production`
+      - app = `blog`
 
 ## Inputs
 

--- a/modules/bucket/README.md
+++ b/modules/bucket/README.md
@@ -4,7 +4,7 @@ This module can be used to quickly get a bucket up and running according to Entu
 
 ## Main effect
 
-Creates a bucket named **team-app-namespace-suffix**: `${var.labels.team}-${var.labels.app}-${var.kubernetes_namespace}-${var.bucket_instance_suffix}`.
+Creates a bucket named **app-namespace-suffix**: `${var.labels.app}-${var.kubernetes_namespace}`.
 
 > NB: The total length of the bucket name cannot exceed 30 characters.
 
@@ -12,28 +12,23 @@ Creates a bucket named **team-app-namespace-suffix**: `${var.labels.team}-${var.
 
 ### Generated Service Account:
 
-- `${var.labels.app}-${substr(var.kubernetes_namespace,0,3)}-${var.bucket_instance_suffix}`
-  - `[app]-[nam(espace)]-[suffix]`
+- `${var.labels.app}-${var.kubernetes_namespace}`
+  - `[app]-[namespace]`
   - Name of the Service Account used by this bucket (name length < 30)
   - Render: `awesome-pro-bucket`
     - given
       - app = `awesomeblog`
       - namespace = `production`
-      - suffix = `bucket`
-
-This seems odd, but stems from the fact that bucket SA cannot be named more than 30 characters longl
 
 ### Generated Kubernetes Secrets:
 
-- `${var.labels.team}-${var.labels.app}-${var.kubernetes_namespace}-${var.bucket_instance_suffix}-credentials` with `{ credentials.json: "PRIVATEKEY" }`
-  - `[team]-[app]-[namespace]-[suffix]-credentials`
+- `${var.labels.app}-bucket-credentials` with `{ credentials.json: "PRIVATEKEY" }`
+  - `[app]-[namespace]-bucket-credentials`
   - Contains the credentials.json service account credentials
-  - Render: `ninja-blog-dev-bucket-credentials`
+  - Render: `blog-bucket-credentials`
     - given
-      - team = `ninja`
       - app = `awesomeblog`
       - namespace = `production`
-      - suffix = `bucket`
 
 ## Inputs
 
@@ -47,12 +42,13 @@ This seems odd, but stems from the fact that bucket SA cannot be named more than
 | location | The location of your bucket | string | n/a | yes |
 | kubernetes_namespace | The namespace you wish to target. This is the namespace that the secrets will be stored in | string | n/a | yes |
 | prevent_destroy | Prevents the destruction of the bucket | bool | false | no |
-| bucket_instance_suffix | A suffix that is added to the bucket, this can be used as a workaround for destroying and creating a bucket (naming collision) | string | "bucket" | no |
-| storage_class | The storage class of the bucket | string | "RGIONAL" | no |
+| storage_class | The storage class of the bucket | string | "REGIONAL" | no |
 | versioning | Should bucket be versioned? | bool | true | no |
 | log_bucket | The bucket's Access & Storage Logs configuration | bool | false | no |
 | bucket_policy_only | Enables Bucket Policy Only access to a bucket | bool | false | no |
-| service_account_bucket_role | Role of the Service Account | string | "READER" | no |
+| service_account_bucket_role | Role of the Service Account | string | "roles/storage.objectViewer" | no |
+| account_id | Storage service account id (name) override | string | "" | no |
+| account_id_use_existing | Set this to true if you want to use an existing service account | bool | false | no |
 
 ## Outputs
 

--- a/modules/bucket/variables.tf
+++ b/modules/bucket/variables.tf
@@ -21,10 +21,6 @@ variable "kubernetes_namespace" {
   description = "Your kubernetes namespace"
 }
 
-variable "bucket_instance_suffix" {
-  description = "A suffix for the bucket instance, may be changed if environment is destroyed and then needed again (name collision workaround) - also bucket names must be globally unique"
-}
-
 variable "force_destroy" {
   description = "(Optional, Default: false) When deleting a bucket, this boolean option will delete all contained objects. If you try to delete a bucket that contains objects, Terraform will fail that run"
   default     = false
@@ -59,4 +55,19 @@ variable "prevent_destroy" {
   description = "Prevent destruction of bucket"
   type        = bool
   default     = false
+}
+
+variable "account_id" {
+  description = "Bucket service account id override (empty string = use standard convention)"
+  default     = ""
+}
+
+variable "account_id_use_existing" {
+  description = "Set this to true if you want to use an existing service account, otherwise a new one will be created (account_id must also be provided if set to true)"
+  default     = false
+}
+
+variable "bucket_instance_custom_name" {
+  description = "Bucket instance name override (empty string = use standard convention)"
+  default     = ""
 }


### PR DESCRIPTION
Improvements to the naming scheme, made to match changes already implemented in the postgres module. 

Involves a number of changes to the default naming scheme of the bucket itself, as well as the generated service account and kubernetes secret.

* adds the option to bring-your-own-service-account or provide a custom sa name
* adds instance name override support
* all use of "team" has been removed from naming schemes (added as labels only)
* removes the "bucket_instance_suffix" input variable
* default naming scheme changes:
  - **bucket instance**: 
  team-app-providedsuffix -> app-namespace-randomsuffix
  platform-swag-bucket123 -> swag-dev-aa42
  - **service account**: 
  app-providedsuffix -> app-namespace
  swag-bucket123 -> swag-dev
  - **kubernetes secret**: 
  team-app-providedsuffix-credentials -> app-bucket-credentials
  platform-swag-bucket123-credentials -> swag-bucket-credentials