### PR TITLE
Bucket module: Remove version constraint from provider in main.tf

### DIFF
--- a/modules/bucket/main.tf
+++ b/modules/bucket/main.tf
@@ -3,7 +3,6 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 2.19"
   project = var.gcp_project
 }
 


### PR DESCRIPTION
The bucket module currently breaks due to a version constraint set in `main.tf`, which shouldn't be there. Terraform tries to match all constraints during initialization, even when other versions are specified in the local config. This PR removes the version parameter, so that the local version configuration can take precedence.

Tested using Terraform v0.13.2 and updated provider refs.

**Before removal:**
```
$ terraform init
Initializing modules...

Initializing the backend...

Initializing provider plugins...
- Using previously-installed hashicorp/kubernetes v1.13.2
- Using previously-installed hashicorp/random v3.0.0
- Using previously-installed hashicorp/google-beta v3.40.0
- Finding hashicorp/google versions matching "~> 3.0, ~> 2.19"...

Error: Failed to query available provider packages

Could not retrieve the list of available versions for provider
hashicorp/google: no available releases match the given constraints ~> 3.0, ~>
2.19
```

**After removal:**
```
$ terraform init
Initializing modules...

Initializing the backend...

Initializing provider plugins...
- Using previously-installed hashicorp/google-beta v3.40.0
- Using previously-installed hashicorp/kubernetes v1.13.2
- Using previously-installed hashicorp/random v3.0.0
- Finding hashicorp/google versions matching "~> 3.0"...
- Installing hashicorp/google v3.46.0...
- Installed hashicorp/google v3.46.0 (signed by HashiCorp)

Terraform has been successfully initialized!
```
