### PR TITLE
Bucket module: Replace deprecated bucket_policy_only attribute with uniform_bucket_level_access

### DIFF
--- a/modules/bucket/README.md
+++ b/modules/bucket/README.md
@@ -44,7 +44,7 @@ Creates a bucket named **app-namespace-suffix**: `${var.labels.app}-${var.kubern
 | storage_class | The storage class of the bucket | string | "REGIONAL" | no |
 | versioning | Should bucket be versioned? | bool | true | no |
 | log_bucket | The bucket's Access & Storage Logs configuration | bool | false | no |
-| bucket_policy_only | Enables Bucket Policy Only access to a bucket | bool | false | no |
+| uniform_bucket_level_access | Enables Uniform bucket-level access access to a bucket | bool | false | no |
 | service_account_bucket_role | Role of the Service Account | string | "roles/storage.objectViewer" | no |
 | account_id | Storage service account id (name) override | string | "" | no |
 | account_id_use_existing | Set this to true if you want to use an existing service account | bool | false | no |

--- a/modules/bucket/main.tf
+++ b/modules/bucket/main.tf
@@ -9,13 +9,13 @@ provider "google" {
 
 # https://www.terraform.io/docs/providers/google/r/storage_bucket.html
 resource "google_storage_bucket" "storage_bucket" {
-  name               = length(var.bucket_instance_custom_name) > 0 ? var.bucket_instance_custom_name : "${var.labels.app}-${var.kubernetes_namespace}-${random_id.suffix.hex}"
-  force_destroy      = var.force_destroy
-  location           = var.location
-  project            = var.gcp_project
-  storage_class      = var.storage_class
+  name                        = length(var.bucket_instance_custom_name) > 0 ? var.bucket_instance_custom_name : "${var.labels.app}-${var.kubernetes_namespace}-${random_id.suffix.hex}"
+  force_destroy               = var.force_destroy
+  location                    = var.location
+  project                     = var.gcp_project
+  storage_class               = var.storage_class
   uniform_bucket_level_access = var.uniform_bucket_level_access
-  labels             = var.labels
+  labels                      = var.labels
 
   versioning {
     enabled = var.versioning
@@ -43,11 +43,11 @@ resource "random_id" "suffix" {
 
 # Create Service account
 resource "google_service_account" "storage_bucket_service_account" {
-  count = var.account_id_use_existing == true ? 0 : 1
+  count        = var.account_id_use_existing == true ? 0 : 1
   account_id   = length(var.account_id) > 0 ? var.account_id : "${var.labels.app}-${var.kubernetes_namespace}"
-  display_name   = length(var.account_id) > 0 ? var.account_id : "${var.labels.app}-${var.kubernetes_namespace}"
-  description = "Service Account for ${var.labels.app} bucket"
-  project = var.gcp_project
+  display_name = length(var.account_id) > 0 ? var.account_id : "${var.labels.app}-${var.kubernetes_namespace}"
+  description  = "Service Account for ${var.labels.app} bucket"
+  project      = var.gcp_project
 }
 
 # Create key for service account
@@ -71,7 +71,7 @@ resource "kubernetes_secret" "storage_bucket_service_account_credentials" {
 
 # Add service account as member to the bucket
 resource "google_storage_bucket_iam_member" "storage_bucket_iam_member" {
-  count = var.account_id_use_existing == true ? 0 : 1
+  count  = var.account_id_use_existing == true ? 0 : 1
   bucket = google_storage_bucket.storage_bucket.name
   role   = var.service_account_bucket_role
   member = "serviceAccount:${google_service_account.storage_bucket_service_account[0].email}"

--- a/modules/bucket/main.tf
+++ b/modules/bucket/main.tf
@@ -14,7 +14,7 @@ resource "google_storage_bucket" "storage_bucket" {
   location           = var.location
   project            = var.gcp_project
   storage_class      = var.storage_class
-  bucket_policy_only = var.bucket_policy_only
+  uniform_bucket_level_access = var.uniform_bucket_level_access
   labels             = var.labels
 
   versioning {

--- a/modules/bucket/main.tf
+++ b/modules/bucket/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 2.19"
+  version = "~> 4.0.0"
   project = var.gcp_project
 }
 

--- a/modules/bucket/variables.tf
+++ b/modules/bucket/variables.tf
@@ -41,7 +41,7 @@ variable "log_bucket" {
   default     = "false"
 }
 
-variable "bucket_policy_only" {
+variable "uniform_bucket_level_access" {
   description = "Enables Bucket Policy Only access to a bucket"
   default     = "false"
 }

--- a/modules/bucket/variables.tf
+++ b/modules/bucket/variables.tf
@@ -42,7 +42,7 @@ variable "log_bucket" {
 }
 
 variable "uniform_bucket_level_access" {
-  description = "Enables Bucket Policy Only access to a bucket"
+  description = "Enables Uniform bucket-level access to a bucket"
   default     = "false"
 }
 


### PR DESCRIPTION
**Uniform bucket-level access** was known as **Bucket Policy Only** (`bucket_policy_only`) during Beta. This has now been changed, introducing changes in the API.
https://cloud.google.com/storage/docs/uniform-bucket-level-access

The use of `bucket_policy_only` will be removed in the next major release of the Google provider, in favor of the equivalent attribute `uniform_bucket_level_access`.
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket#bucket_policy_only

This PR replaces the use of `bucket_policy_only` with `uniform_bucket_level_access`.

```
Warning: Attribute is deprecated

  on .terraform/modules/bucket/modules/bucket/main.tf line 16, in resource "google_storage_bucket" "storage_bucket":
  16:   bucket_policy_only = var.bucket_policy_only

Please use the uniform_bucket_level_access as this field has been renamed by
Google.
```