### PR TITLE
Set minimum req version of google provider from 4.0.0 to 3.38.x

### DIFF
--- a/modules/bucket/main.tf
+++ b/modules/bucket/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 4.0.0"
+  version = "~> 3.38.0"
   project = var.gcp_project
 }
 


### PR DESCRIPTION
Compatibility issues between psql module and google provider v. 4.0.0 - 

`could not retrieve the list of available versions for provider hashicorp/google: no available releases match given constraints ~> 3.51.0., 4.0.0 `

Breaks terraform configurations that uses both psql and bucket modules.