### PR TITLE
Update terraform to 0.13

### DIFF
--- a/examples/bucket-defaults/main.tf
+++ b/examples/bucket-defaults/main.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }
 
 module "bucket" {

--- a/examples/postgres-defaults/main.tf
+++ b/examples/postgres-defaults/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.1"
+  required_version = ">= 0.13"
 }
 
 module "postgres" {

--- a/examples/postgres-defaults/main.tf
+++ b/examples/postgres-defaults/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.1"
 }
 
 module "postgres" {

--- a/examples/redis-defaults/main.tf
+++ b/examples/redis-defaults/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }
 
 module "redis" {

--- a/examples/secret-default/main.tf
+++ b/examples/secret-default/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }
 
 module "my-secret" {

--- a/examples/secret-multiple/main.tf
+++ b/examples/secret-multiple/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }
 
 module "secretKnownAtApply" {

--- a/modules/entur/main.tf
+++ b/modules/entur/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }
 
 resource "null_resource" "label_exists_app" {

--- a/modules/postgres/main.tf
+++ b/modules/postgres/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }
 
 locals {

--- a/modules/postgres/main.tf
+++ b/modules/postgres/main.tf
@@ -40,7 +40,7 @@ resource "google_project_iam_member" "project" {
 //https://registry.terraform.io/modules/GoogleCloudPlatform/sql-db/google/2.0.0/submodules/postgresql
 module "sql-db_postgresql" {
   source  = "GoogleCloudPlatform/sql-db/google//modules/postgresql"
-  version = "2.0.0"
+  version = "5.1.1"
 
   database_version  = var.postgresql_version
   name              = length(var.db_instance_custom_name) > 0 ? var.db_instance_custom_name : "${var.labels.app}-${var.kubernetes_namespace}-${random_id.suffix.hex}"
@@ -64,10 +64,12 @@ module "sql-db_postgresql" {
   user_name = var.db_user
 
   backup_configuration = {
-    enabled            = var.db_instance_backup_enabled
-    start_time         = var.db_instance_backup_time
-    binary_log_enabled = false #cannot be used with postgres
+    enabled                        = var.db_instance_backup_enabled
+    start_time                     = var.db_instance_backup_time
+    location                       = var.db_instance_backup_location
+    point_in_time_recovery_enabled = var.db_instance_backup_point_in_time_recovery_enabled
   }
+  
   create_timeout = var.create_timeout
   delete_timeout = var.delete_timeout
   update_timeout = var.update_timeout

--- a/modules/postgres/variables.tf
+++ b/modules/postgres/variables.tf
@@ -103,3 +103,13 @@ variable "update_timeout" {
   description = "The optional timout that is applied to limit long database updates."
   default     = "10m"
 }
+
+variable "db_instance_backup_location" {
+  description = "What region the backup is stored. If no value is set a region based default is applied, se offical GCP SQL documentation for details."
+  default = null
+}
+
+variable "db_instance_backup_point_in_time_recovery_enabled" {
+  description = "If point int time recovery is enabled or not."
+  default = false
+}

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }
 
 data "google_compute_network" "default-network" {

--- a/modules/secret/main.tf
+++ b/modules/secret/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.19"
+  required_version = ">= 0.13"
 }
 resource "kubernetes_secret" "the-secret" {
   metadata {


### PR DESCRIPTION
Updating terraform to minimum required version 0.13 for all modules. 
It was necessary to also update the postgres google module to at least V5 for this to work. 
There are a couple of changes related backups that was necessary for the terraform config to validate.

All modules are green running `terraform init -backend=false -upgrade; terraform validate`